### PR TITLE
#32480 Fixed dependency versions. Packaging.

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -51,7 +51,7 @@ object DebugBuild : BuildType({
     }
 
     requirements {
-        equals("env.BuildAgentType", "caravela03")
+        equals("env.BuildAgentType", "caravela04")
     }
 
     features {
@@ -121,7 +121,7 @@ object PublicBuild : BuildType({
     }
 
     requirements {
-        equals("env.BuildAgentType", "caravela03")
+        equals("env.BuildAgentType", "caravela04")
     }
 
     features {
@@ -171,7 +171,7 @@ object PublicDeployment : BuildType({
     }
 
     requirements {
-        equals("env.BuildAgentType", "caravela03")
+        equals("env.BuildAgentType", "caravela04")
     }
 
     features {
@@ -236,7 +236,7 @@ object VersionBump : BuildType({
     }
 
     requirements {
-        equals("env.BuildAgentType", "caravela03")
+        equals("env.BuildAgentType", "caravela04")
     }
 
     features {

--- a/README.md
+++ b/README.md
@@ -1,17 +1,8 @@
-# PostSharp.Engineering.ProductTemplate
+# Metalama.Migration
 
-This repo is a template for new repos that are built using `PostSharp.Engineering`.
+This repo contains PostSharp API annotated for migration to Metalama.
 
-This repo assumes it builds a product named `Metalama.Migration`. A _product_, in the context of PostSharp.Engineering, is essentially synonym to a repo, and it can produce several deployable artifacts, typically several NuGet packages. All artifacts in the same product have the same version and build number.
+You can find mapping between PostSharp API and its Metalama equivalent here.
 
-After cloning the repo, you should do this:
-
-* Use `Build.ps1 tools git rename` to rename `Metalama.Migration` into your product name, _with_ dots.
-* Use Visual Studio Code find-and-replace all to rename:
-  * `Metalama.Migration` into your product name _with_ dots,
-  * `MetalamaMigration` into your product name _without_ dots.
-
-The build entry point is `Build.ps1`.
-
-For more instructions, see https://github.com/postsharp/PostSharp.Engineering.
-
+### View migration in the documentation:
+* [PostSharp API Migration](https://doc.metalama.net/migration-api)

--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -5,16 +5,18 @@
     <!-- Properties of NuGet packages-->
     <PropertyGroup>
         <Authors>PostSharp Technologies</Authors>
-        <PackageProjectUrl>https://github.com/postsharp/Caravela</PackageProjectUrl>
-        <PackageTags></PackageTags>
+        <PackageProjectUrl>https://github.com/postsharp/Metalama</PackageProjectUrl>
+        <PackageTags>$(PackageTags) PostSharp Metalama AOP</PackageTags>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageIcon>postsharp.png</PackageIcon>
+        <PackageIcon>metalama.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <!-- Additional content of NuGet packages -->
     <ItemGroup>
-        <None Include="$(AssetsDirectory)\postsharp.png" Visible="false" Pack="true" PackagePath="" />
+        <None Include="$(AssetsDirectory)\metalama.png" Visible="false" Pack="true" PackagePath="" />
+		<None Include="$(MSBuildThisFileDirectory)..\README.md" Visible="false" Pack="true" PackagePath="" />
         <None Include="$(MSBuildThisFileDirectory)..\LICENSE.md" Visible="false" Pack="true" PackagePath="" />
         <None Include="$(MSBuildThisFileDirectory)..\THIRD-PARTY-NOTICES.TXT" Visible="false" Pack="true" PackagePath="" />
     </ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,11 +12,11 @@
     
     <!-- Set the default versions of dependencies -->
     <PropertyGroup>
-        <PostSharpEngineeringVersion>1.0.113-preview</PostSharpEngineeringVersion>
-		    <MetalamaVersion>0.5.80-preview</MetalamaVersion>
-		    <MetalamaVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaVersion>
+        <PostSharpEngineeringVersion>1.0.114-preview</PostSharpEngineeringVersion>
+		<MetalamaVersion>0.5.80-preview</MetalamaVersion>
+		<MetalamaVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaVersion>
         <MetalamaExtensionsVersion>0.5.80-preview</MetalamaExtensionsVersion>
-		    <MetalamaExtensionsVersion Condition="$(VcsBranch)!=''">branch:dev</MetalamaExtensionsVersion>
+		<MetalamaExtensionsVersion Condition="$(VcsBranch)!=''">branch:dev</MetalamaExtensionsVersion>
     </PropertyGroup>
 
     <!-- Override versions (both this product and dependencies) for the local build -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,11 +12,11 @@
     
     <!-- Set the default versions of dependencies -->
     <PropertyGroup>
-        <PostSharpEngineeringVersion>1.0.101-preview</PostSharpEngineeringVersion>
-		<MetalamaVersion>branch:master</MetalamaVersion>
-		<MetalamaVersion Condition="$(VcsBranch.StartsWith('master'))">0.5.79-preview</MetalamaVersion>
-        <MetalamaExtensionsVersion>branch:dev</MetalamaExtensionsVersion>
-		<MetalamaExtensionsVersion Condition="$(VcsBranch.StartsWith('master'))">0.5.79-preview</MetalamaExtensionsVersion>
+        <PostSharpEngineeringVersion>1.0.113-preview</PostSharpEngineeringVersion>
+		<MetalamaVersion>0.5.79-preview</MetalamaVersion>
+		<MetalamaVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaVersion>
+        <MetalamaExtensionsVersion>0.5.79-preview</MetalamaExtensionsVersion>
+		<MetalamaExtensionsVersion Condition="$(VcsBranch)!=''">branch:dev</MetalamaExtensionsVersion>
     </PropertyGroup>
 
     <!-- Override versions (both this product and dependencies) for the local build -->

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "disable"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "1.0.113-preview"
+    "PostSharp.Engineering.Sdk": "1.0.114-preview"
   }
 }

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "disable"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "1.0.101-preview"
+    "PostSharp.Engineering.Sdk": "1.0.113-preview"
   }
 }

--- a/src/Metalama.Migration/Metalama.Migration.csproj
+++ b/src/Metalama.Migration/Metalama.Migration.csproj
@@ -8,6 +8,7 @@
         <RootNamespace>PostSharp</RootNamespace>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <NoWarn>CS1591;CS0659;CS0660;CS0661</NoWarn>
+		<PackageDescription>A package containing annotated PostSharp API, documenting its Metalama equivalent.</PackageDescription>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Changes:
* Changed dependencies versions to build with `dotnet build` correctly.
* Updated Engineering for Merge Publisher change.
* Missing package description and incorrect icon fixed.

